### PR TITLE
Fix warnings, add Changelog files and rename bash-completion/cabal to eta in Cabal file

### DIFF
--- a/epm/changelog
+++ b/epm/changelog
@@ -1,0 +1,2 @@
+* --patches-directory option added for epm install command
+* patchedExtractTarGzFile function will exit if git command fails

--- a/epm/epm.cabal
+++ b/epm/epm.cabal
@@ -24,7 +24,7 @@ Category:           Distribution
 Build-type:         Simple
 Cabal-Version:      >= 1.10
 Extra-Source-Files:
-  README.md bash-completion/cabal bootstrap.sh changelog
+  README.md bash-completion/epm changelog
 
   -- Generated with '../Cabal/misc/gen-extra-source-files.sh | sort'
   tests/PackageTests/Freeze/my.cabal


### PR DESCRIPTION
We have two options: Either remove the changelog file from cabal file or
include a changelog file in the tree. Adding seems to be a better option
to me.

Also avoids this warning:

```
Warning: File listed in epm/epm.cabal file does not exist: bash-completion/cabal
Warning: File listed in epm/epm.cabal file does not exist: bootstrap.sh
Warning: File listed in epm/epm.cabal file does not exist: changelog
```
