### PR TITLE
Force serial builds for epm

### DIFF
--- a/epm/Distribution/Client/Utils.hs
+++ b/epm/Distribution/Client/Utils.hs
@@ -3,6 +3,7 @@
 module Distribution.Client.Utils ( MergeResult(..)
                                  , mergeBy, duplicates, duplicatesBy
                                  , inDir, determineNumJobs, numberOfProcessors
+                                 , determineNumJobs'
                                  , removeExistingFile
                                  , makeAbsoluteToCwd, filePathToByteString
                                  , byteStringToFilePath, tryCanonicalizePath
@@ -116,6 +117,15 @@ determineNumJobs numJobsFlag =
   case numJobsFlag of
     NoFlag        -> 1
     Flag Nothing  -> numberOfProcessors
+    Flag (Just n) -> n
+
+-- | Till Eta supports parallelism even when no Flag is passed, we
+-- define the number of jobs as 1.
+determineNumJobs' :: Flag (Maybe Int) -> Int
+determineNumJobs' numJobsFlag =
+  case numJobsFlag of
+    NoFlag        -> 1
+    Flag Nothing  -> 1
     Flag (Just n) -> n
 
 -- | Given a relative path, make it absolute relative to the current


### PR DESCRIPTION
Temporarily we are making `epm` to build in only serial mode. We will
enable parallel install after Cabal get's compiled with Eta and Eta
get's support for parallelism. See the notes in SetupWrapper.hs for
setup cache exe to find the reason.

When `-j` switch is used for specifying jobs, we emit a warning right
now:

sibi::casey { ~/github/epm }-> epm install -j2 array
Resolving dependencies...
Warning: Parallel builds are currently not supported, using serial build.
...